### PR TITLE
feat: implement RFC7591 Dynamic Client Registration Protocol

### DIFF
--- a/src/auth/OAuthConfig.ts
+++ b/src/auth/OAuthConfig.ts
@@ -17,6 +17,25 @@ export interface OAuthClient {
   redirectUris: string[];
   scopes: string[];
   name: string;
+  // RFC7591 Dynamic Client Registration metadata
+  clientName?: string;
+  clientUri?: string;
+  logoUri?: string;
+  contacts?: string[];
+  tosUri?: string;
+  policyUri?: string;
+  jwksUri?: string;
+  jwks?: object;
+  tokenEndpointAuthMethod?: string;
+  grantTypes?: string[];
+  responseTypes?: string[];
+  softwareId?: string;
+  softwareVersion?: string;
+  // Registration metadata
+  clientIdIssuedAt?: number;
+  clientSecretExpiresAt?: number;
+  registrationAccessToken?: string;
+  registrationClientUri?: string;
 }
 
 export interface AuthorizationCode {
@@ -54,10 +73,59 @@ export interface OAuthServerMetadata {
   authorization_endpoint: string;
   token_endpoint: string;
   introspection_endpoint: string;
+  registration_endpoint?: string; // RFC7591
   scopes_supported: string[];
   response_types_supported: string[];
   grant_types_supported: string[];
   token_endpoint_auth_methods_supported: string[];
+}
+
+// RFC7591 Dynamic Client Registration interfaces
+export interface ClientRegistrationRequest {
+  redirect_uris: string[];
+  token_endpoint_auth_method?: string;
+  grant_types?: string[];
+  response_types?: string[];
+  client_name?: string;
+  client_uri?: string;
+  logo_uri?: string;
+  scope?: string;
+  contacts?: string[];
+  tos_uri?: string;
+  policy_uri?: string;
+  jwks_uri?: string;
+  jwks?: object;
+  software_id?: string;
+  software_version?: string;
+}
+
+export interface ClientRegistrationResponse {
+  client_id: string;
+  client_secret?: string;
+  registration_access_token?: string;
+  registration_client_uri?: string;
+  client_id_issued_at?: number;
+  client_secret_expires_at?: number;
+  redirect_uris: string[];
+  token_endpoint_auth_method?: string;
+  grant_types?: string[];
+  response_types?: string[];
+  client_name?: string;
+  client_uri?: string;
+  logo_uri?: string;
+  scope?: string;
+  contacts?: string[];
+  tos_uri?: string;
+  policy_uri?: string;
+  jwks_uri?: string;
+  jwks?: object;
+  software_id?: string;
+  software_version?: string;
+}
+
+export interface ClientRegistrationError {
+  error: string;
+  error_description?: string;
 }
 
 export const DEFAULT_OAUTH_CONFIG: Partial<OAuthConfig> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,6 +288,12 @@ export async function startHttpServer(): Promise<void> {
     // OAuth token introspection endpoint
     app.post('/oauth/introspect', (req, res) => oauthService.handleIntrospect(req, res));
     
+    // RFC7591 Dynamic Client Registration endpoints
+    app.post('/oauth/register', (req, res) => oauthService.handleClientRegistration(req, res));
+    app.get('/oauth/register/:client_id', (req, res) => oauthService.handleClientRegistration(req, res));
+    app.put('/oauth/register/:client_id', (req, res) => oauthService.handleClientRegistration(req, res));
+    app.delete('/oauth/register/:client_id', (req, res) => oauthService.handleClientRegistration(req, res));
+    
     // OAuth server metadata endpoint
     app.get('/.well-known/oauth-authorization-server', (req, res) => oauthService.handleServerMetadata(req, res));
     
@@ -295,6 +301,8 @@ export async function startHttpServer(): Promise<void> {
     logger.info('  GET/POST /oauth/authorize - Authorization endpoint');
     logger.info('  POST /oauth/token - Token endpoint');
     logger.info('  POST /oauth/introspect - Token introspection');
+    logger.info('  POST /oauth/register - Client registration (RFC7591)');
+    logger.info('  GET/PUT/DELETE /oauth/register/:client_id - Client management (RFC7591)');
     logger.info('  GET /.well-known/oauth-authorization-server - Server metadata');
   }
 
@@ -421,6 +429,8 @@ export async function startHttpServer(): Promise<void> {
       logger.info('  GET/POST /oauth/authorize - Authorization');
       logger.info('  POST /oauth/token - Token exchange');
       logger.info('  POST /oauth/introspect - Token introspection');
+      logger.info('  POST /oauth/register - Client registration (RFC7591)');
+      logger.info('  GET/PUT/DELETE /oauth/register/:client_id - Client management (RFC7591)');
       logger.info('  GET /.well-known/oauth-authorization-server - Server metadata');
     }
   });


### PR DESCRIPTION
Add comprehensive support for OAuth 2.0 Dynamic Client Registration:

- Add RFC7591 client registration interfaces and metadata
- Implement POST /oauth/register for dynamic client creation
- Add GET/PUT/DELETE /oauth/register/:client_id for client management
- Include registration access tokens for secure client operations
- Add proper validation for redirect URIs, grant types, and metadata
- Update server metadata endpoint with registration_endpoint
- Support multiple authentication methods (client_secret_basic, client_secret_post, none)
- Implement RFC7591 compliant error handling and status codes

Closes #9