### PR TITLE
fix: copy HTML templates to dist directory during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc && shx chmod +x dist/*.js",
+    "build": "tsc && shx cp -r src/auth/templates dist/auth/ && shx chmod +x dist/*.js",
     "prepare": "npm run build",
     "dev": "tsc --watch",
     "test": "vitest run",


### PR DESCRIPTION
- Update build script to copy src/auth/templates to dist/auth/templates
- Fixes ENOENT error when loading OAuth callback templates at runtime
- Templates are now available in the correct location after build